### PR TITLE
Fixed issue with dependency on libjson0 and libjson0-dev in main.c and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,12 +73,12 @@ In addition to this, following commands are needed to install the necessary pack
 ```
 $ sudo apt-get install libcurl4-openssl-dev
 
-$ sudo apt-get install libjson0 libjson0-dev
+$ sudo apt-get install libjson-c-dev
 
 ```
 Compile
 ```
-gcc main.c $(pkg-config --libs --cflags libcurl) -l json -std=gnu11
+gcc main.c $(pkg-config --libs --cflags libcurl) -l json-c -std=gnu11
 
 ```
 # Restaurant

--- a/main.c
+++ b/main.c
@@ -3,7 +3,8 @@
 #include <ctype.h>
 #include <stdlib.h>
 #include <curl/curl.h>
-#include <json/json.h>
+#include <json-c/json_object.h>
+#include <json-c/json_tokener.h>
 #include "functions.c"
 
 


### PR DESCRIPTION
#33 
Updated main.c headers to match libjson-c-dev and updated libjson install statement and compile instructions in README.