### PR TITLE
Fixing path to help.txt

### DIFF
--- a/src/response.c
+++ b/src/response.c
@@ -99,9 +99,7 @@ else if ((strcmp(result, "weather") == 0)) {
 
 }    //Help
 else if ((strcmp(str, "help") == 0)) {
-    char * help1 = "less ";
-    char help[1000];
-    sprintf(help, "%s%s%s", help1, HOMEDIR, "help.txt");
+    char * help = "less utils/help.txt";
     system(help);
 } else if ((strcmp(result, "google") == 0)) {
 


### PR DESCRIPTION
Response command to "help" request has been changed from:
less /home/username/Virtual-Assistant/help.txt
to:
less utils/help.txt

1. Using an absolute path for 'help.txt' will likely lead to errors in case the user doesn't customize the "HOME_DIR" in the configuration file 'config' (editing 'username' to actual username).
2. Also, absolute path is unnecessary and a relative path may be used instead.
3. Finally, this edit reflects the last update which moved 'help.txt' to 'utils' directory. 