### PR TITLE
Fixing path to media

### DIFF
--- a/src/response.c
+++ b/src/response.c
@@ -60,10 +60,7 @@ else if ((strcmp(result, "weather") == 0)) {
 } else if ((strcmp(result, "media") == 0)) {
     system("say here are the list of available media");
     printf("Here are the list of available media\n");
-    char * sys_cmd1;
-    char sys_cmd[1000];
-    sys_cmd1 = "ls ";
-    sprintf(sys_cmd, "%s%s%s", sys_cmd1, HOMEDIR, "media/");
+    char * sys_cmd = "ls media";
     system(sys_cmd);
     system("say which media do you want me to play");
     printf("Which media do you want me to play? \n");


### PR DESCRIPTION
Changed media command using absolute path:
ls /home/username/Virtual-Assistant/media/
to using relative path:
ls media

Using an absolute path to 'media' directory will likely lead to errors in case the user doesn't customize the "HOME_DIR" in the configuration file 'config' (editing 'username' to actual username).
Also, absolute path is unnecessary and a relative path may be used instead.