### PR TITLE
Changing int to size_t

### DIFF
--- a/src/analysis.c
+++ b/src/analysis.c
@@ -11,8 +11,8 @@
  */
 
 
-int word = 0, character = 0;
-for (int iter_char = 0; iter_char < strlen(example); iter_char++) {
+size_t word = 0, character = 0;
+for (size_t iter_char = 0; iter_char < strlen(example); iter_char++) {
     example[iter_char] = tolower(example[iter_char]);
     if (example[iter_char] == ' ') {
         if (example[iter_char + 1] != ' ') {
@@ -36,10 +36,10 @@ split[word][character] = '\0';
  * iter_classifier_w - iterates over all words in a single classifier array
  */
 int classification_score = 0;
-for (int class = 0 ; class < LAST_FIELD ; class++) {
-	for (int iter_input = 0; iter_input <= word; iter_input++) {
-		for (int iter_classifier = 0; iter_classifier < NUM_WORDS; iter_classifier++) {
-			for (int iter_classifier_w = 0; iter_classifier_w < WORD_LEN; iter_classifier_w++) {
+for (size_t class = 0 ; class < LAST_FIELD ; class++) {
+	for (size_t iter_input = 0; iter_input <= word; iter_input++) {
+		for (size_t iter_classifier = 0; iter_classifier < NUM_WORDS; iter_classifier++) {
+			for (size_t iter_classifier_w = 0; iter_classifier_w < WORD_LEN; iter_classifier_w++) {
 				if ((classifier[class][iter_classifier][iter_classifier_w]) &&
 						(strcmp(classifier[class][iter_classifier][iter_classifier_w], split[iter_input]) == 0)) {
 					classification_score++;
@@ -57,7 +57,7 @@ for (int class = 0 ; class < LAST_FIELD ; class++) {
 
 int score = 0;
 strcpy(result,"");
-for (int class = 0; class < LAST_FIELD; class++) {
+for (size_t class = 0; class < LAST_FIELD; class++) {
 	if (scores[class] > score) {
 		score = scores[class];
 		strcpy(result, catagories_str[class]);

--- a/src/functions.c
+++ b/src/functions.c
@@ -90,7 +90,7 @@ int find_restaurants() {
     CURL *curl = NULL;
     CURLcode result;
     int i, len;
-    int j, head_length, length; //variables for output formatting
+    size_t j, head_length, length; //variables for output formatting
     char location[1000];
     struct json_object *jobj, *obj1, *obj2, *obj3, *obj4, *lat, *lng; //Geocoding API json objects
     struct json_object *pl1, *pl2, *idx, *name, *price, *vic, *rate, *open, *hrs; //Google Place API json Objects

--- a/src/init_config.c
+++ b/src/init_config.c
@@ -24,7 +24,7 @@ FILE *get_Config_File()
 char *set_HomeDir_Var(FILE *conf)
 {
     //Getting home directory out of configuration file
-    int i = 0;
+    size_t i = 0;
     char cfg_line[1000];
     cfg_line[i] = fgetc(conf);
     char *pos;
@@ -47,7 +47,7 @@ char *set_HomeDir_Var(FILE *conf)
 char *set_MediaPlayer_Var(FILE *conf)
 {
     //Get preferred media player from config file
-    int i = 0;
+    size_t i = 0;
     MediaPlayer[i] = fgetc(conf);
     i++;
     while (MediaPlayer[i - 1] != '\n' && MediaPlayer[i - 1] != EOF)
@@ -68,7 +68,7 @@ char *set_MediaPlayer_Var(FILE *conf)
 char *set_WebBrowser_Var(FILE *conf)
 {
     //Get preferred Webbrowser out of config file
-    int i = 0;
+    size_t i = 0;
     char *pos;
     WebBrowser[i] = fgetc(conf);
     i++;

--- a/src/requests.c
+++ b/src/requests.c
@@ -12,7 +12,7 @@ printf("%s\n", x);
 fgets(str, 1000, stdin);
 
 //Check for spaces as input
-for (int i = 0; str[i]!='\n'; i++)
+for (size_t i = 0; str[i]!='\n'; i++)
 {
     if (str[i] != ' ')
         only_spaces = false;


### PR DESCRIPTION
Changing the integral type of iterations counter from int to size_t, when variable could not be negative and value could overflow size of int.
In some cases this was done also to accomodate to the return type of strlen(), which is size_t.